### PR TITLE
feat: configure cli timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,18 @@ to your CPU core count).
 ]
 ```
 
-### CLI Timeout
+### Timeout
 
-Execution time of the `tailwindcss` CLI can vary from project to project,
-and even environment to environment causing execution to fail if the timeout
-is reached. For larger projects, the CLI timeout can be configured through
-`:cli_timeout`. The default is 10,000ms.
+The `tailwindcss` CLI needs to initialize before it can respond to
+its first request. On slower CI machines or larger projects, this can
+exceed the default timeout of 30 seconds. Adjust with `:timeout`:
 
 ```elixir
 # .formatter.exs
 [
   plugins: [Phoenix.LiveView.HTMLFormatter],
   attribute_formatters: %{class: CanonicalTailwind},
-  canonical_tailwind: [cli_timeout: 30_000],
+  canonical_tailwind: [timeout: 60_000],
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ to your CPU core count).
 ]
 ```
 
+### CLI Timeout
+
+Execution time of the `tailwindcss` CLI can vary from project to project,
+and even environment to environment causing execution to fail if the timeout
+is reached. For larger projects, the CLI timeout can be configured through
+`:cli_timeout`. The default is 10,000ms.
+
+```elixir
+# .formatter.exs
+[
+  plugins: [Phoenix.LiveView.HTMLFormatter],
+  attribute_formatters: %{class: CanonicalTailwind},
+  canonical_tailwind: [cli_timeout: 30_000],
+]
+```
+
 ### Custom binary
 
 If you're not using the `:tailwind` hex package, provide the path to

--- a/lib/canonical_tailwind/canonicalizer.ex
+++ b/lib/canonical_tailwind/canonicalizer.ex
@@ -6,13 +6,17 @@ defmodule CanonicalTailwind.Canonicalizer do
   @impl GenServer
   def init(config) do
     port = open_port(config)
-    {:ok, %{port: port}}
+    {:ok, %{port: port, cli_timeout: config.cli_timeout}}
   end
 
   @impl GenServer
-  def handle_call({:canonicalize, class_string}, _from, %{port: port} = state) do
+  def handle_call(
+        {:canonicalize, class_string},
+        _from,
+        %{port: port, cli_timeout: cli_timeout} = state
+      ) do
     Port.command(port, [class_string, ?\n])
-    result = receive_line(port)
+    result = receive_line(port, cli_timeout)
     {:reply, result, state}
   end
 
@@ -38,10 +42,8 @@ defmodule CanonicalTailwind.Canonicalizer do
     Port.open({:spawn_executable, config.binary}, port_opts)
   end
 
-  @receive_timeout 10_000
-
-  defp receive_line(port) do
-    receive_line(port, [], @receive_timeout)
+  defp receive_line(port, cli_timeout) do
+    receive_line(port, [], cli_timeout)
   end
 
   defp receive_line(port, acc, timeout) do

--- a/lib/canonical_tailwind/canonicalizer.ex
+++ b/lib/canonical_tailwind/canonicalizer.ex
@@ -6,17 +6,17 @@ defmodule CanonicalTailwind.Canonicalizer do
   @impl GenServer
   def init(config) do
     port = open_port(config)
-    {:ok, %{port: port, cli_timeout: config.cli_timeout}}
+    {:ok, %{port: port, timeout: config.timeout}}
   end
 
   @impl GenServer
   def handle_call(
         {:canonicalize, class_string},
         _from,
-        %{port: port, cli_timeout: cli_timeout} = state
+        %{port: port, timeout: timeout} = state
       ) do
     Port.command(port, [class_string, ?\n])
-    result = receive_line(port, cli_timeout)
+    result = receive_line(port, timeout)
     {:reply, result, state}
   end
 
@@ -42,8 +42,8 @@ defmodule CanonicalTailwind.Canonicalizer do
     Port.open({:spawn_executable, config.binary}, port_opts)
   end
 
-  defp receive_line(port, cli_timeout) do
-    receive_line(port, [], cli_timeout)
+  defp receive_line(port, timeout) do
+    receive_line(port, [], timeout)
   end
 
   defp receive_line(port, acc, timeout) do

--- a/lib/canonical_tailwind/config.ex
+++ b/lib/canonical_tailwind/config.ex
@@ -2,17 +2,17 @@ defmodule CanonicalTailwind.Config do
   @moduledoc false
 
   @default_pool_size 6
-  @default_cli_timeout 10_000
+  @default_timeout 30_000
   @minimum_version Version.parse!("4.2.2")
   @non_profile_keys [:version, :version_check, :path, :target, :cacerts_path]
 
-  @enforce_keys [:args, :binary, :cd, :pool_size, :cli_timeout]
+  @enforce_keys [:args, :binary, :cd, :pool_size, :timeout]
   defstruct @enforce_keys
 
   def resolve!(formatter_opts, tailwind_env) do
     opts = Keyword.get(formatter_opts, :canonical_tailwind, [])
     pool_size = validate_pool_size!(opts)
-    cli_timeout = validate_cli_timeout!(opts)
+    timeout = validate_timeout!(opts)
     {binary, profile_config} = resolve_binary!(opts, tailwind_env)
     cd = resolve_cd!(opts, profile_config)
     validate_cd!(cd)
@@ -35,7 +35,7 @@ defmodule CanonicalTailwind.Config do
       binary: binary,
       cd: cd,
       pool_size: pool_size,
-      cli_timeout: cli_timeout
+      timeout: timeout
     }
   end
 
@@ -169,6 +169,17 @@ defmodule CanonicalTailwind.Config do
     size
   end
 
+  defp validate_timeout!(opts) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    unless is_integer(timeout) and timeout > 0 do
+      raise ArgumentError,
+            "expected :timeout to be a positive integer, got: #{inspect(timeout)}."
+    end
+
+    timeout
+  end
+
   defp validate_cd!(cd) do
     unless File.dir?(cd) do
       raise ArgumentError, ":cd path #{inspect(cd)} is not a directory."
@@ -180,16 +191,5 @@ defmodule CanonicalTailwind.Config do
       raise ArgumentError,
             "tailwindcss binary at #{binary} does not exist or is not executable."
     end
-  end
-
-  defp validate_cli_timeout!(opts) do
-    cli_timeout = Keyword.get(opts, :cli_timeout, @default_cli_timeout)
-
-    unless is_integer(cli_timeout) and cli_timeout > 0 do
-      raise ArgumentError,
-            "expected :cli_timeout to be a positive integer, got: #{inspect(cli_timeout)}"
-    end
-
-    cli_timeout
   end
 end

--- a/lib/canonical_tailwind/config.ex
+++ b/lib/canonical_tailwind/config.ex
@@ -2,15 +2,17 @@ defmodule CanonicalTailwind.Config do
   @moduledoc false
 
   @default_pool_size 6
+  @default_cli_timeout 10_000
   @minimum_version Version.parse!("4.2.2")
   @non_profile_keys [:version, :version_check, :path, :target, :cacerts_path]
 
-  @enforce_keys [:args, :binary, :cd, :pool_size]
+  @enforce_keys [:args, :binary, :cd, :pool_size, :cli_timeout]
   defstruct @enforce_keys
 
   def resolve!(formatter_opts, tailwind_env) do
     opts = Keyword.get(formatter_opts, :canonical_tailwind, [])
     pool_size = validate_pool_size!(opts)
+    cli_timeout = validate_cli_timeout!(opts)
     {binary, profile_config} = resolve_binary!(opts, tailwind_env)
     cd = resolve_cd!(opts, profile_config)
     validate_cd!(cd)
@@ -28,7 +30,13 @@ defmodule CanonicalTailwind.Config do
         &is_nil/1
       )
 
-    %__MODULE__{args: args, binary: binary, cd: cd, pool_size: pool_size}
+    %__MODULE__{
+      args: args,
+      binary: binary,
+      cd: cd,
+      pool_size: pool_size,
+      cli_timeout: cli_timeout
+    }
   end
 
   defp resolve_binary!(opts, tailwind_env) do
@@ -172,5 +180,16 @@ defmodule CanonicalTailwind.Config do
       raise ArgumentError,
             "tailwindcss binary at #{binary} does not exist or is not executable."
     end
+  end
+
+  defp validate_cli_timeout!(opts) do
+    cli_timeout = Keyword.get(opts, :cli_timeout, @default_cli_timeout)
+
+    unless is_integer(cli_timeout) and cli_timeout > 0 do
+      raise ArgumentError,
+            "expected :cli_timeout to be a positive integer, got: #{inspect(cli_timeout)}"
+    end
+
+    cli_timeout
   end
 end

--- a/test/canonical_tailwind/config_test.exs
+++ b/test/canonical_tailwind/config_test.exs
@@ -133,18 +133,18 @@ defmodule CanonicalTailwind.ConfigTest do
     end
   end
 
-  describe ":cli_timeout" do
+  describe ":timeout" do
     test "must be a positive integer" do
-      assert_raise ArgumentError, ~r/expected :cli_timeout to be a positive integer/, fn ->
-        resolve!(binary: @binary, cli_timeout: 0)
+      assert_raise ArgumentError, ~r/expected :timeout to be a positive integer/, fn ->
+        resolve!(binary: @binary, timeout: 0)
       end
 
-      assert_raise ArgumentError, ~r/expected :cli_timeout to be a positive integer/, fn ->
-        resolve!(binary: @binary, cli_timeout: -1)
+      assert_raise ArgumentError, ~r/expected :timeout to be a positive integer/, fn ->
+        resolve!(binary: @binary, timeout: -1)
       end
 
-      assert_raise ArgumentError, ~r/expected :cli_timeout to be a positive integer/, fn ->
-        resolve!(binary: @binary, cli_timeout: 1.5)
+      assert_raise ArgumentError, ~r/expected :timeout to be a positive integer/, fn ->
+        resolve!(binary: @binary, timeout: 1.5)
       end
     end
   end

--- a/test/canonical_tailwind/config_test.exs
+++ b/test/canonical_tailwind/config_test.exs
@@ -133,6 +133,22 @@ defmodule CanonicalTailwind.ConfigTest do
     end
   end
 
+  describe ":cli_timeout" do
+    test "must be a positive integer" do
+      assert_raise ArgumentError, ~r/expected :cli_timeout to be a positive integer/, fn ->
+        resolve!(binary: @binary, cli_timeout: 0)
+      end
+
+      assert_raise ArgumentError, ~r/expected :cli_timeout to be a positive integer/, fn ->
+        resolve!(binary: @binary, cli_timeout: -1)
+      end
+
+      assert_raise ArgumentError, ~r/expected :cli_timeout to be a positive integer/, fn ->
+        resolve!(binary: @binary, cli_timeout: 1.5)
+      end
+    end
+  end
+
   defp resolve!(opts) do
     Config.resolve!([canonical_tailwind: opts], [])
   end


### PR DESCRIPTION
Adds a configurable `:timeout` option (default 30s) for the tailwindcss CLI response timeout.

Closes #5